### PR TITLE
Add sentry app argument

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,7 @@ const shelljs_1 = require("shelljs");
 const helm_1 = require("./helm");
 const sentry_1 = require("./sentry");
 function getConfig() {
+    var _a;
     const rawConfig = core.getInput('config', { required: true });
     core.debug(`Parsing raw config '${rawConfig}'...`);
     let config;
@@ -51,7 +52,7 @@ function getConfig() {
       `);
         }
     });
-    ['namespace', 'release'].forEach((optionalKey) => {
+    ['namespace', 'sentryApp', 'release'].forEach((optionalKey) => {
         if (config[optionalKey] && typeof config[optionalKey] !== 'string') {
             throw new Error(common_tags_1.oneLine `
         Expecting string in '${optionalKey}' optional key.
@@ -71,7 +72,7 @@ function getConfig() {
       Found ${config['values']}
     `);
     }
-    return Object.assign({ namespace: 'default', release: config.app, valueFiles: [], values: {} }, config);
+    return Object.assign({ namespace: 'default', release: config.app, sentryApp: (_a = config.sentryApp, (_a !== null && _a !== void 0 ? _a : config.app)), valueFiles: [], values: {} }, config);
 }
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
@@ -79,7 +80,7 @@ function run() {
             const context = github.context;
             // Deployment variables
             const config = getConfig();
-            const { app, appUrl, chart, namespace, release, valueFiles, values } = config;
+            const { app, appUrl, chart, namespace, sentryApp, release, valueFiles, values } = config;
             const environment = core.getInput('environment', { required: true });
             // Helm variables
             const helmRepoName = core.getInput('helmRepoName', { required: false });
@@ -104,6 +105,7 @@ function run() {
             core.debug(`- release: ${release}`);
             core.debug(`- valueFiles: ${valueFiles}`);
             core.debug(`- values: ${values}`);
+            core.debug(`- sentryApp: ${sentryApp}`);
             core.debug(`- sentryAuthToken: ${sentryAuthToken}`);
             core.debug(`- sentryOrg: ${sentryOrg}`);
             core.debug(`- slackWebhook: ${slackWebhook}`);
@@ -130,7 +132,7 @@ function run() {
             helm_1.setupHelmChart(namespace, release, chart, valueFiles);
             // Deploy to Sentry
             if (sentryAuthToken) {
-                sentry_1.setSentryRelease(sentryAuthToken, sentryOrg, app, context.sha, environment);
+                sentry_1.setSentryRelease(sentryAuthToken, sentryOrg, sentryApp, context.sha, environment);
             }
             else {
                 core.info('No sentry auth token was provided. Skipping sentry release');


### PR DESCRIPTION
Allow apps to specify a sentry app argument in the config in order to work around reserved words, e.g. `auth`.